### PR TITLE
Added marker autocomplete for dwarp command

### DIFF
--- a/src/main/java/com/cnaude/dynwarp/DynWarp.java
+++ b/src/main/java/com/cnaude/dynwarp/DynWarp.java
@@ -18,6 +18,7 @@ public class DynWarp extends JavaPlugin {
     @Override
     public void onEnable() {
         getCommand("dwarp").setExecutor(new WarpCommand(this));
+        getCommand("dwarp").setTabCompleter(new WarpAutoComplete(this));
         getCommand("dwlist").setExecutor(new ListCommand(this));
     }
 

--- a/src/main/java/com/cnaude/dynwarp/WarpAutoComplete.java
+++ b/src/main/java/com/cnaude/dynwarp/WarpAutoComplete.java
@@ -1,0 +1,35 @@
+package com.cnaude.dynwarp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.dynmap.DynmapCommonAPI;
+import org.dynmap.markers.Marker;
+import org.dynmap.markers.MarkerAPI;
+import org.dynmap.markers.MarkerSet;
+
+public class WarpAutoComplete implements TabCompleter {
+	private final DynWarp plugin;
+    private final DynmapCommonAPI dynmapCommonAPI;
+	private final MarkerAPI markerAPI;
+	
+	public WarpAutoComplete(DynWarp instance) {
+        this.plugin = instance;
+        this.dynmapCommonAPI = (DynmapCommonAPI) plugin.getServer().getPluginManager().getPlugin("dynmap");
+        markerAPI = dynmapCommonAPI.getMarkerAPI();
+    }
+	
+	@Override
+	public List<String> onTabComplete(final CommandSender sender, Command cmd, String commandLabel, String[] args) {
+		List<String> markers = new ArrayList<String>(); 
+		for (MarkerSet ms : markerAPI.getMarkerSets()) {
+            for (Marker m : ms.getMarkers()) {
+                markers.add(m.getMarkerID());
+            }
+        }
+		return markers;
+	}
+}


### PR DESCRIPTION
I added a tab autocomplete feature for the /dwarp command. It gets the list of markers from the dynmap api similarly to the WarpCommand class and returns the list of markers to be used with the tab autocomplete feature for Bukkit. Originally it was defaulting to autocompleting online player names instead.